### PR TITLE
Fix a CTD from the mcedit main menu

### DIFF
--- a/mcedit.py
+++ b/mcedit.py
@@ -699,20 +699,6 @@ class MCEdit(GLViewport):
             config.config.set("Recent Worlds", str(i), filename.encode('utf-8'))
 
     def makeSideColumn(self):
-        def showhistory():
-            try:
-                with file(os.path.join(mcplatform.dataDir, 'history.txt')) as f:
-                    history = f.read()
-
-                history = "\n".join(history.split("\n")[:16])
-
-                history += "\n ... see history.txt for more ... "
-            except Exception, e:
-                history = "Exception while reading history.txt: {0}".format(e)
-
-            if ask(history, ["Show history.txt", "OK"]) == "Show history.txt":
-                platform_open(os.path.join(mcplatform.dataDir, "history.txt"))
-
         def showLicense():
             platform_open(os.path.join(mcplatform.dataDir, "LICENSE.txt"))
 
@@ -735,7 +721,7 @@ class MCEdit(GLViewport):
                   lambda: platform_open(readmePath)),
                   ("",
                   "Recent Changes",
-                  showhistory),
+                  lambda: platform_open("https://github.com/mcedit/mcedit/wiki/Version-History")),
                   ("",
                   "License",
                   showLicense),


### PR DESCRIPTION
A few brackets were missing, causing mcedit to crash to desktop whenever the user tried to select 'show history.txt' from the 'Recent changes' alert box. Also fixed so that the contents of 'history.txt' will show in the popup if the file exists (it currently does not).

If nobody is planning to create a history.txt then it's probably best to remove 'Recent changes' altogether.
