### PR TITLE
fix mouse jumping bug

### DIFF
--- a/leveleditor.py
+++ b/leveleditor.py
@@ -2292,7 +2292,7 @@ class LevelEditor(GLViewport):
             self.dragInProgress = True
             self.dragStartPoint = (x,y)
             self.currentOperation.dragStart(x,y)
-      '
+      
     def mouseDragOff(self):
         if self.dragInProgress:
             self.dragInProgress = False


### PR DESCRIPTION
This looks like a pygame bug and it may be Mac only. The first mouse move event after (re)gaining focus and then hiding the cursor has incorrect relative coordinates, causing the mouse to jump to some extreme. I used a state variable to detect the condition and drop the event.
