### PR TITLE
Update filter.py to Allow String Input for Filters

### DIFF
--- a/editortools/filter.py
+++ b/editortools/filter.py
@@ -79,6 +79,13 @@ class FilterModuleOptions(Widget):
                 elif optionType == "label":
                     rows.append(wrapped_label(optionName, 50))
 
+                elif optionType == "string":
+                    field = TextField(value="string")
+                    self.optionDict[optionName] = AttrRef(field, 'value')
+                    
+                    row = Row((Label(optionName), field))
+                    rows.append(row)
+
                 else:
                     raise ValueError(("Unknown option type", optionType))
 


### PR DESCRIPTION
The proposed change takes advantage of the TextField class in the albow package to allow filters to accept string input from the user.  May be of use to filter creators.
