### PR TITLE
"Fixed" the invisible dialog error, as in #209

### DIFF
--- a/albow/widget.py
+++ b/albow/widget.py
@@ -743,7 +743,7 @@ class Widget(object):
             GLU.gluOrtho2D(0, w, 0, h)
             GL.glMatrixMode(GL.GL_MODELVIEW)
             GL.glLoadIdentity()
-            GL.glRasterPos2i(rect.left, h - rect.bottom)
+            GL.glRasterPos2i(max(rect.left, 0), max(h - rect.bottom, 0))
             GL.glPushAttrib(GL.GL_COLOR_BUFFER_BIT)
             GL.glEnable(GL.GL_BLEND)
             GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)


### PR DESCRIPTION
The problem was that if you center a dialog wider/taller than the screen, it will overflow. Since albow draws widgets by openGL, it won't accept negative coordinates for the bottom left corner. my hotfix minimizes these coordinates.

This is not a complete solution, and some of the filters, for example, will still be out of the screen. At least no more totally invisible widgets.

I really hope this pullreq will be attached to #209. If not, sorry.
